### PR TITLE
Fix property mismatch in dialog buttons

### DIFF
--- a/lib/function/button.dart
+++ b/lib/function/button.dart
@@ -173,15 +173,15 @@ class _ButtonPageState extends State<ButtonPage> {
           actions: <Widget>[
             TextButton(
               style: ButtonStyle(
-                overlayColor: WidgetStateProperty.resolveWith<Color?>(
-                  (Set<WidgetState> states) {
-                    if (states.contains(WidgetState.pressed) || states.contains(WidgetState.hovered)) {
+                overlayColor: MaterialStateProperty.resolveWith<Color?>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.pressed) || states.contains(MaterialState.hovered)) {
                       return const Color.fromARGB(255, 237, 237, 237);
                     }
                     return null;
                   },
                 ),
-                foregroundColor: WidgetStateProperty.all<Color>(Colors.black),
+                foregroundColor: MaterialStateProperty.all<Color>(Colors.black),
               ),
               child: const Text('确定'),
               onPressed: () {

--- a/lib/function/installApp.dart
+++ b/lib/function/installApp.dart
@@ -195,15 +195,15 @@ class _InstallAppPageState extends State<InstallAppPage> {
           actions: <Widget>[
             TextButton(
               style: ButtonStyle(
-                overlayColor: WidgetStateProperty.resolveWith<Color?>(
-                  (Set<WidgetState> states) {
-                    if (states.contains(WidgetState.pressed) || states.contains(WidgetState.hovered)) {
+                overlayColor: MaterialStateProperty.resolveWith<Color?>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.pressed) || states.contains(MaterialState.hovered)) {
                       return const Color.fromARGB(255, 237, 237, 237); // 点击或悬浮时的背景颜色
                     }
                     return null; // 默认状态下不更改颜色
                   },
                 ),
-                foregroundColor: WidgetStateProperty.all<Color>(Colors.black), // 文本颜色
+                foregroundColor: MaterialStateProperty.all<Color>(Colors.black), // 文本颜色
               ),
               child: const Text('确定'),
               onPressed: () {

--- a/lib/function/pair.dart
+++ b/lib/function/pair.dart
@@ -219,15 +219,15 @@ class _PairPageState extends State<PairPage> {
           actions: <Widget>[
             TextButton(
               style: ButtonStyle(
-                overlayColor: WidgetStateProperty.resolveWith<Color?>(
-                  (Set<WidgetState> states) {
-                    if (states.contains(WidgetState.pressed) || states.contains(WidgetState.hovered)) {
+                overlayColor: MaterialStateProperty.resolveWith<Color?>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.pressed) || states.contains(MaterialState.hovered)) {
                       return const Color.fromARGB(255, 237, 237, 237);
                     }
                     return null;
                   },
                 ),
-                foregroundColor: WidgetStateProperty.all<Color>(Colors.black),
+                foregroundColor: MaterialStateProperty.all<Color>(Colors.black),
               ),
               child: const Text('确定'),
               onPressed: () {

--- a/lib/function/rotate.dart
+++ b/lib/function/rotate.dart
@@ -164,15 +164,15 @@ class _RotatePageState extends State<RotatePage> {
           actions: <Widget>[
             TextButton(
               style: ButtonStyle(
-                overlayColor: WidgetStateProperty.resolveWith<Color?>(
-                  (Set<WidgetState> states) {
-                    if (states.contains(WidgetState.pressed) || states.contains(WidgetState.hovered)) {
+                overlayColor: MaterialStateProperty.resolveWith<Color?>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.pressed) || states.contains(MaterialState.hovered)) {
                       return const Color.fromARGB(255, 237, 237, 237);
                     }
                     return null;
                   },
                 ),
-                foregroundColor: WidgetStateProperty.all<Color>(Colors.black),
+                foregroundColor: MaterialStateProperty.all<Color>(Colors.black),
               ),
               child: const Text('确定'),
               onPressed: () {

--- a/lib/page2.dart
+++ b/lib/page2.dart
@@ -192,15 +192,15 @@ class Page2 extends StatelessWidget {
           actions: <Widget>[
             TextButton(
               style: ButtonStyle(
-                overlayColor: WidgetStateProperty.resolveWith<Color?>(
-                  (Set<WidgetState> states) {
-                    if (states.contains(WidgetState.pressed) || states.contains(WidgetState.hovered)) {
+                overlayColor: MaterialStateProperty.resolveWith<Color?>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.pressed) || states.contains(MaterialState.hovered)) {
                       return const Color.fromARGB(255, 237, 237, 237);
                     }
                     return null;
                   },
                 ),
-                foregroundColor: WidgetStateProperty.all<Color>(Colors.black),
+                foregroundColor: MaterialStateProperty.all<Color>(Colors.black),
               ),
               child: const Text('确定'),
               onPressed: () {

--- a/lib/wireless.dart
+++ b/lib/wireless.dart
@@ -158,15 +158,15 @@ class _WirelessPageState extends State<WirelessPage> {
           actions: <Widget>[
             TextButton(
               style: ButtonStyle(
-                overlayColor: WidgetStateProperty.resolveWith<Color?>(
-                  (Set<WidgetState> states) {
-                    if (states.contains(WidgetState.pressed) || states.contains(WidgetState.hovered)) {
+                overlayColor: MaterialStateProperty.resolveWith<Color?>(
+                  (Set<MaterialState> states) {
+                    if (states.contains(MaterialState.pressed) || states.contains(MaterialState.hovered)) {
                       return const Color.fromARGB(255, 237, 237, 237);
                     }
                     return null;
                   },
                 ),
-                foregroundColor: WidgetStateProperty.all<Color>(Colors.black),
+                foregroundColor: MaterialStateProperty.all<Color>(Colors.black),
               ),
               child: const Text('确定'),
               onPressed: () {


### PR DESCRIPTION
## Summary
- correct usage of `MaterialStateProperty` in various dialog buttons

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f49e9ac0083318bf14694de3c8a4a